### PR TITLE
translator: /v1/models + bedrock provider: surface inference profiles

### DIFF
--- a/cmd/goop/main.go
+++ b/cmd/goop/main.go
@@ -68,6 +68,14 @@ func main() {
 		// compat passthrough rather than the Converse translator).
 		authed.Handle("/bedrock-translate/v1/chat/completions", bh)
 		authed.Handle("/openai-bedrock/v1/chat/completions", bh)
+
+		// Some OpenAI-shape clients (open-webui, LiteLLM) probe /v1/models
+		// when validating a connection. Without this, the translator's URL
+		// space looks half-broken: chat works but the connection itself
+		// shows as unhealthy in the UI. Reuse the native bedrock catalog.
+		mh := translator.NewModelsHandler(bp, logger)
+		authed.Handle("/bedrock-translate/v1/models", mh)
+		authed.Handle("/openai-bedrock/v1/models", mh)
 	}
 
 	root := http.NewServeMux()

--- a/internal/translator/models.go
+++ b/internal/translator/models.go
@@ -1,0 +1,61 @@
+package translator
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/robertprast/goop/internal/provider"
+)
+
+// ModelsHandler serves /bedrock-translate/v1/models (and the legacy
+// /openai-bedrock/v1/models alias). The translator is a single chat-completions
+// endpoint, not a full provider, so it has no entry in the proxy registry —
+// without this handler the path falls through to the catch-all proxyHandler
+// and 404s with "no provider matches", which trips up OpenAI-shape clients
+// that probe /v1/models on connection setup (open-webui, LiteLLM, etc.).
+//
+// We surface the same model list the native bedrock provider returns from
+// ListFoundationModels, since that's exactly the catalog the translator can
+// route to via Converse.
+type ModelsHandler struct {
+	provider provider.Provider
+	logger   *slog.Logger
+}
+
+// NewModelsHandler wraps the bedrock provider so its model catalog is
+// reachable under the translator's URL space.
+func NewModelsHandler(p provider.Provider, logger *slog.Logger) *ModelsHandler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &ModelsHandler{provider: p, logger: logger}
+}
+
+// ServeHTTP returns the bedrock catalog as an OpenAI list-models response.
+// GET-only; HEAD is allowed to keep liveness probes cheap.
+func (h *ModelsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		http.Error(w, `{"error":{"message":"method not allowed","type":"invalid_request"}}`, http.StatusMethodNotAllowed)
+		return
+	}
+
+	models, err := h.provider.ListModels(r.Context())
+	if err != nil {
+		h.logger.Warn("translator models: list failed", "err", err)
+		writeJSONError(w, http.StatusBadGateway, "list_models", err.Error())
+		return
+	}
+	if models == nil {
+		models = []provider.Model{}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if r.Method == http.MethodHead {
+		return
+	}
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"object": "list",
+		"data":   models,
+	})
+}

--- a/internal/translator/models_test.go
+++ b/internal/translator/models_test.go
@@ -1,0 +1,141 @@
+package translator
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/robertprast/goop/internal/provider"
+)
+
+type fakeListProvider struct {
+	stubProvider
+	models []provider.Model
+	err    error
+	calls  int
+}
+
+func (f *fakeListProvider) ListModels(_ context.Context) ([]provider.Model, error) {
+	f.calls++
+	return f.models, f.err
+}
+
+func TestModelsHandler_HappyPath(t *testing.T) {
+	want := []provider.Model{
+		{ID: "bedrock/anthropic.claude-sonnet-4-5-20250929-v1:0", Object: "model", OwnedBy: "Anthropic", Provider: "bedrock"},
+		{ID: "bedrock/us.amazon.nova-pro-v1:0", Object: "model", OwnedBy: "Amazon", Provider: "bedrock"},
+	}
+	p := &fakeListProvider{models: want}
+	h := NewModelsHandler(p, nil)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/bedrock-translate/v1/models", nil)
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("content-type = %q, want application/json", got)
+	}
+
+	var body struct {
+		Object string           `json:"object"`
+		Data   []provider.Model `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body.Object != "list" {
+		t.Errorf("object = %q, want list", body.Object)
+	}
+	if len(body.Data) != len(want) {
+		t.Fatalf("data len = %d, want %d", len(body.Data), len(want))
+	}
+	for i, m := range body.Data {
+		if m.ID != want[i].ID {
+			t.Errorf("data[%d].id = %q, want %q", i, m.ID, want[i].ID)
+		}
+	}
+	if p.calls != 1 {
+		t.Errorf("ListModels called %d times, want 1", p.calls)
+	}
+}
+
+func TestModelsHandler_EmptyListIsValidJSON(t *testing.T) {
+	// Provider that returns (nil, nil) shouldn't yield "data": null — that
+	// breaks strict OpenAI clients that expect an array.
+	p := &fakeListProvider{models: nil}
+	h := NewModelsHandler(p, nil)
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/bedrock-translate/v1/models", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var body struct {
+		Data []provider.Model `json:"data"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body.Data == nil {
+		t.Fatalf("data is null; want []")
+	}
+	if len(body.Data) != 0 {
+		t.Fatalf("data = %v, want []", body.Data)
+	}
+}
+
+func TestModelsHandler_RejectsPost(t *testing.T) {
+	h := NewModelsHandler(&fakeListProvider{}, nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/bedrock-translate/v1/models", nil))
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", rec.Code)
+	}
+}
+
+func TestModelsHandler_HEADOmitsBody(t *testing.T) {
+	p := &fakeListProvider{models: []provider.Model{{ID: "bedrock/x"}}}
+	h := NewModelsHandler(p, nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodHead, "/bedrock-translate/v1/models", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if rec.Body.Len() != 0 {
+		t.Fatalf("HEAD body should be empty, got %d bytes", rec.Body.Len())
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Errorf("content-type = %q, want application/json", got)
+	}
+}
+
+func TestModelsHandler_UpstreamErrorIs502(t *testing.T) {
+	p := &fakeListProvider{err: errors.New("bedrock unavailable")}
+	h := NewModelsHandler(p, nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/bedrock-translate/v1/models", nil))
+
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", rec.Code)
+	}
+	var env struct {
+		Error struct {
+			Type    string `json:"type"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Fatalf("unmarshal error envelope: %v", err)
+	}
+	if env.Error.Type != "list_models" {
+		t.Errorf("error.type = %q, want list_models", env.Error.Type)
+	}
+}


### PR DESCRIPTION
Two related fixes that together make `/bedrock-translate/v1` a fully working OpenAI-shape connection in clients like open-webui.

## 1. Translator: serve `/v1/models`

OpenAI-shape clients (open-webui, LiteLLM, …) probe `/v1/models` when registering a connection. The translator only exposed `/v1/chat/completions`, so the request fell through to the proxy registry's catch-all and 404'd:

```
GET /bedrock-translate/v1/models
→ 404 {"error":{"message":"no provider matches \"/bedrock-translate/v1/models\"","type":"no_provider"}}
```

open-webui then marked the connection as broken and hid any manually-pinned model IDs. Adding a `ModelsHandler` that proxies the native bedrock catalog into OpenAI list-models shape fixes the validation step and gives users auto-discovery.

Mounted at:

```
GET /bedrock-translate/v1/models
GET /openai-bedrock/v1/models   (legacy alias)
```

GET-only (HEAD permitted for cheap probes); POST → 405. Empty catalog returns `"data": []` not `null` so strict OpenAI clients don't trip on the shape. Upstream errors surface as `502` with `{"error":{"type":"list_models",...}}`.

## 2. Bedrock provider: pull inference profiles too

Once `/v1/models` started flowing, the catalog was visibly missing every Anthropic Claude ID (and every other cross-region-only model). Cause: `bedrockNative.ListModels` was filtering on `InferenceTypesSupported.contains(ON_DEMAND)`, but Anthropic Claude 3.5+, Sonnet 4.x, Haiku 4.x, etc. declare `INFERENCE_PROFILE` as their only inference type. They were getting silently dropped, even though Converse via `/bedrock-translate` happily accepts `us.anthropic.claude-sonnet-4-5-20250929-v1:0` as a model field.

Fix: walk `ListInferenceProfiles` after `ListFoundationModels` and emit each `ACTIVE` profile under `bedrock/<InferenceProfileId>`. Dedupe with a `seen` set so cross-region-prefix duplicates don't double up. `ListInferenceProfiles` errors don't fail the whole call — older regions / accounts without that API still get the foundation-model list.

Owner is read off the first `ModelArn` in the profile so Claude profiles report `"Anthropic"` instead of `""`.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — full suite green, including:
  - `TestModelsHandler_*` (5 cases: happy path, empty list → `[]` not `null`, POST→405, HEAD body suppression, upstream error → 502)
  - `TestOwnerFromProfile` (5 cases: Anthropic ARN, Amazon ARN, malformed-then-valid fallback, no ARNs, ARN missing provider segment)
- [ ] Reviewer: optional manual smoke against a live AWS account — `curl -H "Authorization: Bearer $GOOP_API_KEY" http://localhost:8080/bedrock-translate/v1/models | jq '.data[].id' | grep anthropic`

🤖 Generated with [Claude Code](https://claude.com/claude-code)