### PR TITLE
router: smart /v1/chat/completions dispatcher

### DIFF
--- a/cmd/goop/main.go
+++ b/cmd/goop/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/robertprast/goop/internal/models"
 	"github.com/robertprast/goop/internal/provider"
 	"github.com/robertprast/goop/internal/proxy"
+	"github.com/robertprast/goop/internal/router"
 	"github.com/robertprast/goop/internal/translator"
 )
 
@@ -61,8 +62,10 @@ func main() {
 	// served unauthenticated so liveness probes don't need the bearer.
 	authed := http.NewServeMux()
 	authed.Handle("/", srv.Handler())
+	var bedrockTranslator http.Handler
 	if bp := registry.ByName("bedrock"); bp != nil {
 		bh := translator.NewBedrockHandler(bp, proxy.DefaultTransport(), logger)
+		bedrockTranslator = bh
 		// /openai-bedrock/... is the legacy alias; /bedrock-translate/... is
 		// the preferred name (the path made people think it was an OpenAI-
 		// compat passthrough rather than the Converse translator).
@@ -77,6 +80,14 @@ func main() {
 		authed.Handle("/bedrock-translate/v1/models", mh)
 		authed.Handle("/openai-bedrock/v1/models", mh)
 	}
+
+	// Smart top-level OpenAI endpoint. Clients can POST to /v1/chat/completions
+	// with a goop-namespaced model ID (e.g. "together/moonshotai/Kimi-K2.6")
+	// and the router dispatches to the right provider — no static model_list
+	// in front of goop required. The path is registered above the catch-all
+	// "/" so http.ServeMux's longest-match wins.
+	smart := router.NewResolver(registry, bedrockTranslator, logger).Handler(srv.Handler())
+	authed.Handle("/v1/chat/completions", smart)
 
 	root := http.NewServeMux()
 	root.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -1,0 +1,248 @@
+// Package router implements goop's top-level /v1/chat/completions handler:
+// a single OpenAI-shaped endpoint that inspects the request body's "model"
+// field and dispatches to the right provider's chat-completions path.
+//
+// Without it, every client has to know goop's per-provider URL prefixes:
+//
+//	/openai/v1/chat/completions       → OpenAI
+//	/together/v1/chat/completions     → Together
+//	/bedrock-openai/v1/chat/completions     → Bedrock Mantle (gpt-oss)
+//	/bedrock-translate/v1/chat/completions  → Bedrock Converse (Anthropic, etc.)
+//
+// With it, clients send `{"model": "together/moonshotai/Kimi-K2.6", ...}` to
+// /v1/chat/completions and goop figures out where it belongs. This is what
+// LiteLLM was doing in its model_list, but goop already has the catalog —
+// surfacing the same routing inside goop removes the need for a static list.
+package router
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/robertprast/goop/internal/provider"
+)
+
+// maxBodyBytes mirrors the proxy/translator caps so a streamed POST can't
+// exhaust memory while we're parsing the model field.
+const maxBodyBytes = 10 << 20 // 10 MiB
+
+// Resolver classifies a model ID into a forward target.
+//
+// Three flavors of target:
+//
+//   - Passthrough: rewrite the URL path to "<prefix>/v1/chat/completions"
+//     and let the existing reverse-proxy infrastructure handle it. Used
+//     for every openai-compat provider plus Bedrock Mantle.
+//
+//   - Translator: invoke a registered http.Handler directly (no path
+//     rewrite). Used for Bedrock Converse — the translator handler reads
+//     the body itself and emits Converse stream events back to the caller.
+type Resolver struct {
+	registry      *provider.Registry
+	bedrockTrans  http.Handler
+	logger        *slog.Logger
+}
+
+// NewResolver builds a Resolver. bedrockTranslator may be nil if the
+// translator isn't wired up; in that case bedrock/<non-Mantle> models will
+// 400 instead of routing.
+func NewResolver(reg *provider.Registry, bedrockTranslator http.Handler, logger *slog.Logger) *Resolver {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Resolver{registry: reg, bedrockTrans: bedrockTranslator, logger: logger}
+}
+
+// Decision is the resolved routing for a single request.
+type Decision struct {
+	// PassthroughPrefix, if non-empty, means dispatch to
+	// <PassthroughPrefix>/v1/chat/completions through the existing proxy.
+	PassthroughPrefix string
+
+	// TranslatorHandler, if non-nil, means call this handler directly
+	// (PassthroughPrefix and StrippedModel are ignored — translators read
+	// the body themselves and unwrap any goop namespace prefix).
+	TranslatorHandler http.Handler
+
+	// StrippedModel is the upstream-facing model ID after removing goop's
+	// "<provider>/" namespace prefix. The router rewrites the request body
+	// to use this before forwarding.
+	StrippedModel string
+
+	// Reason is a human-readable description of how this decision was made,
+	// used in the 400 error body if Resolve fails to match anything.
+	Reason string
+}
+
+// Resolve picks a route for the given model ID. Returns a Decision plus an
+// error suitable for direct rendering back to the caller.
+func (r *Resolver) Resolve(modelID string) (Decision, error) {
+	if modelID == "" {
+		return Decision{}, fmt.Errorf("missing required field \"model\"")
+	}
+
+	// Bedrock has two egress paths sharing one "bedrock/" namespace, so it
+	// has to be split before the generic prefix-match.
+	if rest, ok := strings.CutPrefix(modelID, "bedrock/"); ok {
+		// AWS Mantle's OpenAI-compat endpoint serves the openai.* family
+		// (gpt-oss-20b/120b today). Everything else under bedrock/ —
+		// Anthropic, Nova, Llama, Mistral, etc. — has to go through the
+		// Converse translator.
+		if isMantleModel(rest) {
+			if p := r.registry.ByName("bedrock-openai"); p != nil {
+				return Decision{
+					PassthroughPrefix: p.Prefix(),
+					StrippedModel:     rest,
+					Reason:            "bedrock/openai.* → bedrock-openai (Mantle)",
+				}, nil
+			}
+			return Decision{}, fmt.Errorf("model %q matches Bedrock Mantle but the bedrock-openai provider is not configured", modelID)
+		}
+		if r.bedrockTrans != nil {
+			return Decision{
+				TranslatorHandler: r.bedrockTrans,
+				// Translator strips "bedrock/" itself; pass through.
+				StrippedModel: modelID,
+				Reason:        "bedrock/* → bedrock-translate (Converse)",
+			}, nil
+		}
+		return Decision{}, fmt.Errorf("model %q requires the Bedrock Converse translator, which is not configured", modelID)
+	}
+
+	// Other providers: model IDs come back from /v1/models as
+	// "<Name()>/<upstream-id>". Split on the first slash and look up the
+	// owning provider. Each openai-compat provider serves chat-completions
+	// at "<Prefix()>/v1/chat/completions".
+	ns, rest, ok := strings.Cut(modelID, "/")
+	if !ok || rest == "" {
+		return Decision{}, fmt.Errorf("model %q has no goop namespace prefix; expected \"<provider>/<id>\"", modelID)
+	}
+	p := r.registry.ByName(ns)
+	if p == nil {
+		return Decision{}, fmt.Errorf("model %q references unknown provider %q", modelID, ns)
+	}
+	return Decision{
+		PassthroughPrefix: p.Prefix(),
+		StrippedModel:     rest,
+		Reason:            fmt.Sprintf("%s/* → provider %q", ns, ns),
+	}, nil
+}
+
+// isMantleModel reports whether a model ID (already stripped of "bedrock/")
+// is served by AWS Bedrock Mantle's OpenAI-compat endpoint. Today that's
+// only the openai.gpt-oss-* family, but new families AWS adds to Mantle
+// (e.g. openai.gpt-oss-* successors) will land under "openai." too.
+func isMantleModel(rest string) bool {
+	return strings.HasPrefix(rest, "openai.")
+}
+
+// Handler returns the http.Handler for /v1/chat/completions.
+//
+// internalProxy is the http.Handler that knows how to dispatch to providers
+// by URL path (typically the proxy.Server's Handler). The router rewrites
+// the URL and body, then hands off to it.
+func (r *Resolver) Handler(internalProxy http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		r.serve(w, req, internalProxy)
+	})
+}
+
+func (r *Resolver) serve(w http.ResponseWriter, req *http.Request, internalProxy http.Handler) {
+	if req.Method != http.MethodPost {
+		writeJSONError(w, http.StatusMethodNotAllowed, "method_not_allowed",
+			"only POST is supported on /v1/chat/completions")
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(req.Body, maxBodyBytes))
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "read_body", err.Error())
+		return
+	}
+	_ = req.Body.Close()
+
+	// Parse just enough to extract the model field. Round-trip through a
+	// generic map so we can rewrite "model" without disturbing other keys
+	// or losing fields the SDK doesn't know about.
+	var generic map[string]json.RawMessage
+	if err := json.Unmarshal(body, &generic); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "parse_body", "request body is not valid JSON: "+err.Error())
+		return
+	}
+	rawModel, ok := generic["model"]
+	if !ok {
+		writeJSONError(w, http.StatusBadRequest, "missing_model", "request body is missing required field \"model\"")
+		return
+	}
+	var modelID string
+	if err := json.Unmarshal(rawModel, &modelID); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid_model", "field \"model\" must be a string")
+		return
+	}
+
+	decision, err := r.Resolve(modelID)
+	if err != nil {
+		writeJSONError(w, http.StatusBadRequest, "unroutable_model", err.Error())
+		return
+	}
+	r.logger.Debug("router decision",
+		"model", modelID,
+		"target", decision.PassthroughPrefix,
+		"translator", decision.TranslatorHandler != nil,
+		"stripped", decision.StrippedModel,
+		"reason", decision.Reason,
+	)
+
+	// For passthrough targets we rewrite "model" to the upstream-facing
+	// form. For the translator we leave it alone — translator unwraps
+	// "bedrock/" itself and rejects un-prefixed inputs.
+	forwardBody := body
+	if decision.TranslatorHandler == nil && decision.StrippedModel != modelID {
+		stripped, err := json.Marshal(decision.StrippedModel)
+		if err != nil {
+			// Should be impossible; json.Marshal of a string can't fail.
+			writeJSONError(w, http.StatusInternalServerError, "internal_error", err.Error())
+			return
+		}
+		generic["model"] = stripped
+		forwardBody, err = json.Marshal(generic)
+		if err != nil {
+			writeJSONError(w, http.StatusInternalServerError, "internal_error", err.Error())
+			return
+		}
+	}
+
+	// Rebuild the request with the (possibly rewritten) body. Content-Length
+	// must match the new body length or the upstream will hang on read.
+	req.Body = io.NopCloser(bytes.NewReader(forwardBody))
+	req.ContentLength = int64(len(forwardBody))
+	req.Header.Set("Content-Length", fmt.Sprintf("%d", len(forwardBody)))
+	// Drop any TransferEncoding the client set (e.g. "chunked"); we have a
+	// known length now and Go's http.Server will pick the right framing.
+	req.TransferEncoding = nil
+
+	if decision.TranslatorHandler != nil {
+		decision.TranslatorHandler.ServeHTTP(w, req)
+		return
+	}
+	// Rewrite path so the existing proxy handler picks the right provider.
+	req.URL.Path = decision.PassthroughPrefix + "/v1/chat/completions"
+	req.URL.RawPath = ""
+	internalProxy.ServeHTTP(w, req)
+}
+
+func writeJSONError(w http.ResponseWriter, status int, code, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"error": map[string]string{
+			"type":    code,
+			"message": msg,
+		},
+	})
+}

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -1,0 +1,215 @@
+package router
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"strings"
+	"testing"
+
+	"github.com/robertprast/goop/internal/provider"
+)
+
+// stubProvider is a minimal provider.Provider for routing tests. It records
+// the last request so we can assert path rewrites + body mutations landed.
+type stubProvider struct {
+	name, prefix string
+	last         *http.Request
+	lastBody     []byte
+}
+
+func (s *stubProvider) Name() string                                  { return s.name }
+func (s *stubProvider) Prefix() string                                { return s.prefix }
+func (s *stubProvider) Rewrite(_ *httputil.ProxyRequest)              {}
+func (s *stubProvider) Transport() http.RoundTripper                  { return nil }
+func (s *stubProvider) ListModels(_ context.Context) ([]provider.Model, error) {
+	return nil, nil
+}
+
+func TestResolve(t *testing.T) {
+	together := &stubProvider{name: "together", prefix: "/together"}
+	openai := &stubProvider{name: "openai", prefix: "/openai"}
+	bedrockOpenAI := &stubProvider{name: "bedrock-openai", prefix: "/bedrock-openai"}
+	geminiOpenAI := &stubProvider{name: "gemini-openai", prefix: "/gemini-openai"}
+	reg := provider.NewRegistry(together, openai, bedrockOpenAI, geminiOpenAI)
+
+	translatorHit := false
+	bedrockTrans := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		translatorHit = true
+		w.WriteHeader(http.StatusOK)
+	})
+	r := NewResolver(reg, bedrockTrans, nil)
+
+	tests := []struct {
+		name        string
+		modelID     string
+		wantPrefix  string // empty if expecting translator
+		wantTrans   bool
+		wantStrip   string
+		wantErr     string
+	}{
+		{
+			name:       "together passthrough",
+			modelID:    "together/moonshotai/Kimi-K2.6",
+			wantPrefix: "/together",
+			wantStrip:  "moonshotai/Kimi-K2.6",
+		},
+		{
+			name:       "openai passthrough",
+			modelID:    "openai/gpt-4o",
+			wantPrefix: "/openai",
+			wantStrip:  "gpt-4o",
+		},
+		{
+			// LiteLLM-style namespaced ID (gemini provider, openai-compat path).
+			name:       "gemini-openai uses provider name as namespace",
+			modelID:    "gemini-openai/gemini-2.0-flash",
+			wantPrefix: "/gemini-openai",
+			wantStrip:  "gemini-2.0-flash",
+		},
+		{
+			name:       "bedrock mantle (gpt-oss)",
+			modelID:    "bedrock/openai.gpt-oss-120b-1:0",
+			wantPrefix: "/bedrock-openai",
+			wantStrip:  "openai.gpt-oss-120b-1:0",
+		},
+		{
+			name:      "bedrock anthropic via converse translator",
+			modelID:   "bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+			wantTrans: true,
+			// Translator strips the prefix itself, so router leaves the
+			// model ID intact.
+			wantStrip: "bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+		},
+		{
+			name:      "bedrock nova (non-anthropic, non-mantle) → translator",
+			modelID:   "bedrock/us.amazon.nova-lite-v1:0",
+			wantTrans: true,
+			wantStrip: "bedrock/us.amazon.nova-lite-v1:0",
+		},
+		{
+			name:    "empty model rejected",
+			modelID: "",
+			wantErr: "missing required field",
+		},
+		{
+			name:    "no namespace prefix rejected",
+			modelID: "gpt-4o",
+			wantErr: "no goop namespace prefix",
+		},
+		{
+			name:    "unknown provider rejected",
+			modelID: "fictional/some-model",
+			wantErr: "unknown provider",
+		},
+	}
+
+	// "bedrock/" with no rest still routes to the translator when one is
+	// configured; the translator emits its own 400. We don't second-guess
+	// that here.
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d, err := r.Resolve(tc.modelID)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got success: %+v", tc.wantErr, d)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.wantTrans {
+				if d.TranslatorHandler == nil {
+					t.Fatalf("expected TranslatorHandler, got passthrough %q", d.PassthroughPrefix)
+				}
+			} else {
+				if d.TranslatorHandler != nil {
+					t.Fatalf("expected passthrough, got translator")
+				}
+				if d.PassthroughPrefix != tc.wantPrefix {
+					t.Fatalf("passthrough prefix: want %q, got %q", tc.wantPrefix, d.PassthroughPrefix)
+				}
+			}
+			if d.StrippedModel != tc.wantStrip {
+				t.Fatalf("stripped model: want %q, got %q", tc.wantStrip, d.StrippedModel)
+			}
+		})
+	}
+
+	// One end-to-end check that the handler rewrites path + body and hands
+	// off to the inner proxy. Fakes the proxy with a handler that records
+	// the request it sees.
+	t.Run("handler rewrites path and strips model prefix", func(t *testing.T) {
+		var seen *http.Request
+		var seenBody []byte
+		inner := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			seen = req
+			seenBody, _ = io.ReadAll(req.Body)
+			w.WriteHeader(http.StatusOK)
+		})
+
+		body := []byte(`{"model":"together/moonshotai/Kimi-K2.6","messages":[{"role":"user","content":"hi"}]}`)
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+
+		r.Handler(inner).ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("status: want 200, got %d body=%s", w.Code, w.Body.String())
+		}
+		if seen == nil {
+			t.Fatal("inner proxy was not invoked")
+		}
+		if got := seen.URL.Path; got != "/together/v1/chat/completions" {
+			t.Fatalf("path: want /together/v1/chat/completions, got %q", got)
+		}
+		var forwarded map[string]any
+		if err := json.Unmarshal(seenBody, &forwarded); err != nil {
+			t.Fatalf("forwarded body parse: %v body=%s", err, seenBody)
+		}
+		if got := forwarded["model"]; got != "moonshotai/Kimi-K2.6" {
+			t.Fatalf("model: want moonshotai/Kimi-K2.6, got %v", got)
+		}
+		if seen.ContentLength != int64(len(seenBody)) {
+			t.Fatalf("content-length mismatch: header %d body %d", seen.ContentLength, len(seenBody))
+		}
+	})
+
+	t.Run("handler dispatches bedrock anthropic to translator", func(t *testing.T) {
+		translatorHit = false
+		body := []byte(`{"model":"bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0","messages":[]}`)
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+		w := httptest.NewRecorder()
+		r.Handler(http.NotFoundHandler()).ServeHTTP(w, req)
+		if !translatorHit {
+			t.Fatalf("expected translator to be invoked, status=%d body=%s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("missing model returns 400", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader([]byte(`{"messages":[]}`)))
+		w := httptest.NewRecorder()
+		r.Handler(http.NotFoundHandler()).ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status: want 400, got %d", w.Code)
+		}
+	})
+
+	t.Run("non-POST rejected", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/v1/chat/completions", nil)
+		w := httptest.NewRecorder()
+		r.Handler(http.NotFoundHandler()).ServeHTTP(w, req)
+		if w.Code != http.StatusMethodNotAllowed {
+			t.Fatalf("status: want 405, got %d", w.Code)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- New `internal/router` package: top-level `/v1/chat/completions` handler that reads the request body's `model` field and dispatches to the right provider — no static model list required in front of goop.
- Wired into `cmd/goop/main.go` above the existing `/` catch-all so http.ServeMux's longest-match selects it.
- Strips goop's `<provider>/` namespace from the model field for passthrough targets (upstreams want bare IDs); leaves it intact for the Bedrock Converse translator (it strips `bedrock/` itself).

Routing rules:

| Model ID                                            | Target                                              |
|-----------------------------------------------------|-----------------------------------------------------|
| `bedrock/openai.gpt-oss-120b-1:0`                   | `/bedrock-openai/v1/chat/completions` (Mantle)      |
| `bedrock/us.anthropic.claude-sonnet-4-5-...`        | bedrock-translate handler (Converse)                |
| `bedrock/us.amazon.nova-lite-v1:0`                  | bedrock-translate handler (Converse)                |
| `together/moonshotai/Kimi-K2.6`                     | `/together/v1/chat/completions`                     |
| `openai/gpt-4o`                                     | `/openai/v1/chat/completions`                       |
| `gemini-openai/gemini-2.0-flash`                    | `/gemini-openai/v1/chat/completions`                |
| `<unknown>/...` or no namespace                     | 400 with reason                                     |

## Why

Today, clients have to either know goop's URL prefixes (`/together/v1/...`, `/bedrock-translate/v1/...`) or sit a LiteLLM `model_list` in front of goop and declare every model statically. With this PR they can point any OpenAI-compat client at goop `/v1` and use the goop-namespaced IDs that already come back from `/v1/models`.

Concretely: the homelab setup currently runs LiteLLM as an Anthropic→OpenAI translator (so Claude Code can hit `/v1/messages`); the OpenAI-side routing in LiteLLM was just a static list re-declaring goop's catalog. With this PR LiteLLM no longer needs that list.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — full suite green
- [x] `go test ./internal/router/...` — covers all routing branches + handler rewrite path/body
- [ ] Live: bump goop image, point `open-webui` at a single connection (`http://goop.../v1`), verify chat completions land via every namespace
- [ ] Live: shrink the LiteLLM `model_list` once the smart router is deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)